### PR TITLE
Refatorar: Remove parsers de comentário redundantes e integra no pars…

### DIFF
--- a/0.js
+++ b/0.js
@@ -86,7 +86,14 @@ const nome = regex(/[a-zA-ZÀ-ÿ_][a-zA-ZÀ-ÿ0-9_]*/);
 
 const endereço = regex(/\S+/);
 
-const espaço = regex(/\s+/);
+// Matches one or more whitespace characters OR a single-line comment
+const um_espaço_ou_comentário = alt(
+  regex(/\s+/), // Matches one or more whitespace characters
+  seq(símbolo("//"), regex(/[^\n]*\n?/)) // Matches a comment line (// until newline)
+);
+
+// Consumes multiple instances of whitespace blocks or comments
+const espaço = vários(um_espaço_ou_comentário);
 
 const número = transformar(regex(/\d+/), v => () => parseInt(v));
 
@@ -401,17 +408,6 @@ const expressão = operação(
   ),
 );
 
-const comentário = transformar(
-  seq(
-    símbolo("//"),
-    regex(/[^\n]*/),
-    opcional(espaço),
-  ),
-  () => () => null
-);
-
-const ignorar_comentários = vários(comentário);
-
 const declarações_constantes = vários(
   seq(
     seq(
@@ -427,7 +423,7 @@ const declarações_constantes = vários(
 
 const _0 = transformar(
   seq(
-    opcional(ignorar_comentários),
+    opcional(espaço),
     opcional(vários(
       seq(
         seq(
@@ -452,9 +448,9 @@ const _0 = transformar(
         espaço,
       ),
     ), []),
-    opcional(ignorar_comentários),
+    opcional(espaço),
     opcional(declarações_constantes, []),
-    opcional(ignorar_comentários),
+    opcional(espaço),
     expressão,
   ),
   ([, importaçõesDetectadas, carregamentosDetectados, , atribuições, , valor]) => {


### PR DESCRIPTION
…er de espaço

Remove os parsers `comentário` e `ignorar_comentários`. A sintaxe de comentário (linhas iniciadas com `//`) agora é tratada diretamente pelo parser `espaço`.

Modificações:
- O parser `espaço` foi alterado para consumir tanto sequências de caracteres de espaço em branco quanto linhas de comentário (`//` até o final da linha).
- Os parsers `comentário` e `ignorar_comentários` foram removidos.
- Todas as utilizações de `ignorar_comentários` (especificamente em `opcional(ignorar_comentários)`) foram substituídas por `opcional(espaço)`.

Executei os seus testes existentes (69 no total) e todos passaram, confirmando que a refatoração foi bem-sucedida e o comportamento de parsing de comentários e espaços permanece correto.