### PR TITLE
Adicionar suporte ao valor nulo `~` na sintaxe

### DIFF
--- a/código/analisador_léxico/index.js
+++ b/código/analisador_léxico/index.js
@@ -118,6 +118,13 @@ const texto = transformar(
   })
 )
 
+const nulo = transformar(
+  símbolo("~"),
+  () => ({
+    tipo: TIPO_AST.NULO
+  })
+)
+
 // Parser for address literals (file paths and URLs) as expression values
 // Recognizes patterns like: soma.0, ./soma.0, ../dir/soma.0, https://example.com/soma.0
 const endereço_literal = transformar(
@@ -187,5 +194,6 @@ export {
   nome,
   endereço,
   endereço_literal,
-  texto
+  texto,
+  nulo
 };

--- a/código/analisador_semântico/básico.js
+++ b/código/analisador_semântico/básico.js
@@ -2,7 +2,7 @@
 
 import { buscarVariável, INTERNAL_CONTEXT } from './escopo.js';
 import { pushFrame, popFrame, getSnapshotForError } from './pilha.js';
-import { ANSI, TIPO_AST } from '../constantes.js';
+import { ANSI, TIPO_AST, NAO_MANIPULADO } from '../constantes.js';
 
 // Forward declaration for recursive avaliar reference
 let avaliar;
@@ -12,6 +12,9 @@ export const avaliarBásico = async (ast, escopo) => {
     case TIPO_AST.NÚMERO:
     case TIPO_AST.TEXTO:
       return ast.valor;
+
+    case TIPO_AST.NULO:
+      return null;
 
     case TIPO_AST.VARIÁVEL:
       return await buscarVariável(escopo, ast.nome);
@@ -145,7 +148,7 @@ export const avaliarBásico = async (ast, escopo) => {
     }
 
     default:
-      return null; // Not handled by this module
+      return NAO_MANIPULADO; // Not handled by this module
   }
 };
 

--- a/código/analisador_semântico/coleção.js
+++ b/código/analisador_semântico/coleção.js
@@ -1,5 +1,5 @@
 // Collection operations - fatia, tamanho, chaves, atributo
-import { TIPO_AST } from '../constantes.js';
+import { TIPO_AST, NAO_MANIPULADO } from '../constantes.js';
 
 // Forward declaration for recursive avaliar reference
 let avaliar;
@@ -142,7 +142,7 @@ export const avaliarColeção = async (ast, escopo) => {
     }
 
     default:
-      return null; // Not handled by this module
+      return NAO_MANIPULADO; // Not handled by this module
   }
 };
 

--- a/código/analisador_semântico/função.js
+++ b/código/analisador_semântico/função.js
@@ -2,7 +2,7 @@
 
 import { buscarVariável } from './escopo.js';
 import { pushFrame, popFrame, getSnapshotForError } from './pilha.js';
-import { TIPO_AST } from '../constantes.js';
+import { TIPO_AST, NAO_MANIPULADO } from '../constantes.js';
 
 // Forward declaration for recursive avaliar reference
 let avaliar;
@@ -149,7 +149,7 @@ export const avaliarFunção = async (ast, escopo) => {
     }
 
     default:
-      return null; // Not handled by this module
+      return NAO_MANIPULADO; // Not handled by this module
   }
 };
 

--- a/código/analisador_semântico/index.js
+++ b/código/analisador_semântico/index.js
@@ -3,6 +3,7 @@
 
 // Import scope management
 export { criarEscopo, buscarVariável, definirVariável, criarLazyThunk, INTERNAL_CONTEXT } from './escopo.js';
+import { NAO_MANIPULADO } from '../constantes.js';
 
 // Import evaluation modules
 import { avaliarBásico, setAvaliar as setAvaliarBásico } from './básico.js';
@@ -23,22 +24,22 @@ export const avaliar = async (ast, escopo) => {
   let result;
   
   result = await avaliarBásico(ast, escopo);
-  if (result !== null) return result;
+  if (result !== NAO_MANIPULADO) return result;
   
   result = await avaliarOperações(ast, escopo);
-  if (result !== null) return result;
+  if (result !== NAO_MANIPULADO) return result;
   
   result = await avaliarLista(ast, escopo);
-  if (result !== null) return result;
+  if (result !== NAO_MANIPULADO) return result;
 
   result = await avaliarObjeto(ast, escopo);
-  if (result !== null) return result;
+  if (result !== NAO_MANIPULADO) return result;
   
   result = await avaliarColeção(ast, escopo);
-  if (result !== null) return result;
+  if (result !== NAO_MANIPULADO) return result;
   
   result = await avaliarFunção(ast, escopo);
-  if (result !== null) return result;
+  if (result !== NAO_MANIPULADO) return result;
 
   const erro = new Error(`Unknown AST node type: ${ast.tipo}`);
   erro.é_erro_semântico = true;

--- a/código/analisador_semântico/lista.js
+++ b/código/analisador_semântico/lista.js
@@ -1,5 +1,5 @@
 // List construction and evaluation (handles AST nodes with tipo 'lista')
-import { TIPO_AST } from '../constantes.js';
+import { TIPO_AST, NAO_MANIPULADO } from '../constantes.js';
 
 // Forward declaration for recursive avaliar reference
 let avaliar;
@@ -18,7 +18,7 @@ const obterEndereçoMódulo = (escopo) => {
 
 export const avaliarLista = async (ast, escopo) => {
   if (ast.tipo !== 'lista') {
-    return null; // Not handled by this module
+    return NAO_MANIPULADO; // Not handled by this module
   }
 
   if (ast.usarObjeto) {

--- a/código/analisador_semântico/objeto.js
+++ b/código/analisador_semântico/objeto.js
@@ -1,5 +1,5 @@
 // Object construction and evaluation
-import { TIPO_AST } from '../constantes.js';
+import { TIPO_AST, NAO_MANIPULADO } from '../constantes.js';
 
 // Forward declaration for recursive avaliar reference
 let avaliar;
@@ -18,7 +18,7 @@ const obterEndereçoMódulo = (escopo) => {
 
 export const avaliarObjeto = async (ast, escopo) => {
   if (ast.tipo !== 'objeto') {
-    return null; // Not handled by this module
+    return NAO_MANIPULADO; // Not handled by this module
   }
 
   // Expect object-style semantics (curly braces). Parser enforces no value-only items inside {}.

--- a/código/analisador_semântico/operações.js
+++ b/código/analisador_semântico/operações.js
@@ -1,5 +1,5 @@
 // Binary, logical, and conditional operations
-import { TIPO_AST } from '../constantes.js';
+import { TIPO_AST, NAO_MANIPULADO } from '../constantes.js';
 
 // Forward declaration for recursive avaliar reference
 let avaliar;
@@ -45,7 +45,7 @@ export const avaliarOperações = async (ast, escopo) => {
     }
 
     default:
-      return null; // Not handled by this module
+      return NAO_MANIPULADO; // Not handled by this module
   }
 };
 

--- a/código/analisador_sintático/básico.js
+++ b/código/analisador_sintático/básico.js
@@ -1,6 +1,6 @@
 // Basic operations - não, valor_constante, chamada_função_imediata
 import { alternativa, sequência, opcional, transformar, símbolo, vários } from '../combinadores/index.js';
-import { espaço, nome } from '../analisador_léxico/index.js';
+import { espaço, nome, nulo } from '../analisador_léxico/index.js';
 import { TIPO_AST } from '../constantes.js';
 
 // Forward declaration for recursive expressão reference
@@ -148,4 +148,4 @@ const setOperações = (ops) => {
   chamada_função = ops.chamada_função;
 };
 
-export { não, depuração, carregar, valor_constante, chamada_função_imediata, setExpressão, setOperações };
+export { não, depuração, carregar, nulo, valor_constante, chamada_função_imediata, setExpressão, setOperações };

--- a/código/analisador_sintático/index.js
+++ b/código/analisador_sintático/index.js
@@ -2,7 +2,7 @@
 // This module imports from sub-modules and wires everything together
 
 // Import basic operations
-import { não, depuração, carregar, valor_constante, chamada_função_imediata, setExpressão as setExpressãoBásico, setOperações } from './básico.js';
+import { não, depuração, carregar, nulo, valor_constante, chamada_função_imediata, setExpressão as setExpressãoBásico, setOperações } from './básico.js';
 
 // Import object and list operations
 import { objeto, atributo, setExpressão as setExpressãoObjeto } from './objeto.js';
@@ -22,6 +22,7 @@ setDependências(null, {
   não,
   depuração,
   carregar,
+  nulo,
   valor_constante,
   chamada_função_imediata,
   fatia,
@@ -63,6 +64,7 @@ setDependências(expressão, {
   não,
   depuração,
   carregar,
+  nulo,
   valor_constante,
   chamada_função_imediata,
   fatia,

--- a/código/analisador_sintático/termos.js
+++ b/código/analisador_sintático/termos.js
@@ -8,7 +8,7 @@ import { TIPO_AST } from '../constantes.js';
 let expressão;
 
 // Import basic operations
-let não, depuração, carregar, valor_constante, chamada_função_imediata;
+let não, depuração, carregar, nulo, valor_constante, chamada_função_imediata;
 
 // Import object operations
 let fatia, tamanho, chaves, lista, objeto, atributo;
@@ -121,6 +121,7 @@ const getTermo2 = () => alternativa(
   não,
   depuração,
   carregar,
+  nulo,
   valor_constante,
   parênteses
 );
@@ -236,6 +237,7 @@ const setDependências = (expr, deps) => {
   não = deps.não;
   depuração = deps.depuração;
   carregar = deps.carregar;
+  nulo = deps.nulo;
   valor_constante = deps.valor_constante;
   chamada_função_imediata = deps.chamada_função_imediata;
   fatia = deps.fatia;

--- a/código/constantes.js
+++ b/código/constantes.js
@@ -55,4 +55,8 @@ export const TIPO_AST = {
   CONDICIONAL: 'condicional',
   ESPALHAMENTO: 'espalhamento',
   ENDEREÇO_LITERAL: 'endereço_literal',
+  NULO: 'nulo',
 };
+
+// Símbolo para indicar que um nó da AST não foi manipulado por um módulo avaliador
+export const NAO_MANIPULADO = Symbol('NAO_MANIPULADO');

--- a/testes/0
+++ b/testes/0
@@ -12,6 +12,7 @@ uniteste.exibir(
     ./sintaxe/declarações_módulo.0
     ./sintaxe/importação_módulo_valor.0
     ./sintaxe/lista.0
+    ./sintaxe/nulo.0
     ./sintaxe/comentário_bloco.0
     ./texto/documentation_examples.0
     ./texto/edge_cases_division.0

--- a/testes/sintaxe/nulo.0
+++ b/testes/sintaxe/nulo.0
@@ -1,0 +1,32 @@
+uniteste = ../integração/uniteste.0
+
+uniteste.descrever({ nome: "Nulo" testes: [
+  uniteste.iguais([
+    ~
+    ~
+  ])
+  uniteste.iguais([
+    (a = ~ a)
+    ~
+  ])
+  uniteste.iguais([
+    ~ == ~
+    1
+  ])
+  uniteste.iguais([
+    ~ != ~
+    0
+  ])
+  uniteste.iguais([
+    ~ == 0
+    0
+  ])
+  uniteste.iguais([
+    [~][0]
+    ~
+  ])
+  uniteste.iguais([
+    {a: ~}.a
+    ~
+  ])
+]})


### PR DESCRIPTION
Este PR adiciona o suporte ao valor nulo (representado pelo caractere `~`) na Linguagem 0.

As mudanças incluem:
1.  **Léxico e Sintaxe:** Reconhecimento do símbolo `~` e sua inclusão na gramática como um termo básico.
2.  **Semântica:** O valor `~` é avaliado como `null` no JavaScript subjacente.
3.  **Arquitetura:** Para evitar ambiguidade entre o valor literal `null` e o sinalizador de "nó não tratado" nos módulos de avaliação, introduzi o símbolo `NAO_MANIPULADO`. Todos os módulos avaliadores foram atualizados para seguir este novo protocolo.
4.  **Testes:** Novos testes em `testes/sintaxe/nulo.0` verificam a paridade entre valores nulos, atribuição, uso em listas/objetos e comparações.

---
*PR created automatically by Jules for task [15056212431204161555](https://jules.google.com/task/15056212431204161555) started by @angelonuffer*