### PR TITLE
Adiciona testes de região para o analisador léxico

### DIFF
--- a/testar.js
+++ b/testar.js
@@ -5,6 +5,7 @@ import lógica from "./testes/lógica.js"
 import variáveis from "./testes/variáveis.js"
 import texto from "./testes/texto.js"
 import listas from "./testes/listas.js"
+import região from "./testes/região.js"
 
 const resultado = testar([
   ...aritmética,
@@ -13,6 +14,7 @@ const resultado = testar([
   ...variáveis,
   ...texto,
   ...listas,
+  ...região,
 ])
 
 process.stdout.write(resultado.saída + "\n")

--- a/testes/comum.js
+++ b/testes/comum.js
@@ -3,24 +3,26 @@ import { analisador_léxico, analisador_sintático } from "../0.js";
 export const teste = ({
   entrada,
   símbolos = [],
-  árvore = {},
-  saída = "",
-  erro = "",
-}) => [{
-  função: analisador_léxico,
-  argumento: entrada,
-  retorno_esperado: símbolos,
-}, {
-  função: entrada => analisador_sintático(
-    analisador_léxico(entrada)
-  ),
-  argumento: entrada,
-  retorno_esperado: árvore,
-}, /* {
-  função: interpretar,
-  argumento: { entrada, arquivo: "testar.js" },
-  retorno_esperado: {
-    saída,
-    erro,
+  ...opções
+}) => [
+  {
+    função: analisador_léxico,
+    argumento: entrada,
+    retorno_esperado: símbolos,
   },
-} */ ]
+  ...("árvore" in opções ? [{
+    função: entrada => analisador_sintático(
+      analisador_léxico(entrada)
+    ),
+    argumento: entrada,
+    retorno_esperado: opções.árvore,
+  }] : []),
+  /* {
+    função: interpretar,
+    argumento: { entrada, arquivo: "testar.js" },
+    retorno_esperado: {
+      saída: opções.saída,
+      erro: opções.erro,
+    },
+  } */
+]

--- a/testes/região.js
+++ b/testes/região.js
@@ -1,0 +1,107 @@
+import { bloco } from "../texto.js"
+import { teste } from "./comum.js"
+
+export default [
+  ...teste({
+    entrada: "123",
+    símbolos: [
+      { valor: "123", início: 0, fim: 3, tipo: "número" }
+    ]
+  }),
+  ...teste({
+    entrada: "  abc",
+    símbolos: [
+      { valor: "abc", início: 2, fim: 5, tipo: "identificador" }
+    ]
+  }),
+  ...teste({
+    entrada: "a + b",
+    símbolos: [
+      { valor: "a", início: 0, fim: 1, tipo: "identificador" },
+      { valor: "+", início: 2, fim: 3, tipo: "operador" },
+      { valor: "b", início: 4, fim: 5, tipo: "identificador" }
+    ]
+  }),
+  ...teste({
+    entrada: "&& || ==",
+    símbolos: [
+      { valor: "&&", início: 0, fim: 2, tipo: "operador" },
+      { valor: "||", início: 3, fim: 5, tipo: "operador" },
+      { valor: "==", início: 6, fim: 8, tipo: "operador" }
+    ]
+  }),
+  ...teste({
+    entrada: "( [ ] )",
+    símbolos: [
+      { valor: "(", início: 0, fim: 1, tipo: "pontuação" },
+      { valor: "[", início: 2, fim: 3, tipo: "pontuação" },
+      { valor: "]", início: 4, fim: 5, tipo: "pontuação" },
+      { valor: ")", início: 6, fim: 7, tipo: "pontuação" }
+    ]
+  }),
+  ...teste({
+    entrada: '"texto"',
+    símbolos: [
+      { valor: '"texto"', início: 0, fim: 7, tipo: "texto" }
+    ]
+  }),
+  ...teste({
+    entrada: '`modelo ${ expressao }`',
+    símbolos: [
+      { valor: '`modelo ${', início: 0, fim: 10, tipo: "modelo_texto" },
+      { valor: "expressao", início: 11, fim: 20, tipo: "identificador" },
+      { valor: "}`", início: 21, fim: 23, tipo: "modelo_texto" }
+    ]
+  }),
+  ...teste({
+    entrada: "// comentário\n42",
+    símbolos: [
+      { valor: "42", início: 14, fim: 16, tipo: "número" }
+    ]
+  }),
+  ...teste({
+    entrada: bloco(`
+      . a
+      . b
+    `),
+    símbolos: [
+      { valor: "a", início: 0, fim: 1, tipo: "identificador" },
+      { valor: "b", início: 2, fim: 3, tipo: "identificador" }
+    ]
+  }),
+  ...teste({
+    entrada: "#lista",
+    símbolos: [
+      { valor: "#", início: 0, fim: 1, tipo: "pontuação" },
+      { valor: "lista", início: 1, fim: 6, tipo: "identificador" }
+    ]
+  }),
+  ...teste({
+    entrada: "...spread",
+    símbolos: [
+      { valor: "...", início: 0, fim: 3, tipo: "pontuação" },
+      { valor: "spread", início: 3, fim: 9, tipo: "identificador" }
+    ]
+  }),
+  ...teste({
+    entrada: ">= <= != !",
+    símbolos: [
+      { valor: ">=", início: 0, fim: 2, tipo: "operador" },
+      { valor: "<=", início: 3, fim: 5, tipo: "operador" },
+      { valor: "!=", início: 6, fim: 8, tipo: "operador" },
+      { valor: "!", início: 9, fim: 10, tipo: "operador" }
+    ]
+  }),
+  ...teste({
+    entrada: bloco(`
+      . \`multilinha
+      .   \${ 1 }
+      . \`
+    `),
+    símbolos: [
+      { valor: "`multilinha\n  ${", início: 0, fim: 16, tipo: "modelo_texto" },
+      { valor: "1", início: 17, fim: 18, tipo: "número" },
+      { valor: "}\n`", início: 19, fim: 22, tipo: "modelo_texto" }
+    ]
+  })
+]


### PR DESCRIPTION
I have implemented the requested changes to include comprehensive lexical region tests.

Key changes:
1. **Utility Update**: Modified `testes/comum.js` to allow `analisador_sintático` tests to be skipped if the `árvore` property is not provided in the test object. This allows for focused testing of the lexical analyzer.
2. **New Test Suite**: Created `testes/região.js` containing tests for various token types (numbers, identifiers, operators, punctuation, strings, and template strings) and edge cases (comments, whitespace, and multiline template strings), specifically verifying the `início` and `fim` offsets.
3. **Integration**: Added the new `região` tests to `testar.js`.

All 93 tests (including the 13 new test cases) are passing.

---
*PR created automatically by Jules for task [4859487352656196774](https://jules.google.com/task/4859487352656196774) started by @angelonuffer*